### PR TITLE
Fixed some stuff i ran into while trying to get rake html to work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'http://rubygems.org'
+
+gem 'rake'
+gem 'mustache'
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,14 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    mustache (0.11.2)
+    nokogiri (1.4.3.1)
+    rake (0.8.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mustache
+  nokogiri
+  rake

--- a/lib/read-ruby.rb
+++ b/lib/read-ruby.rb
@@ -43,4 +43,4 @@ end
 
 Dir[File.dirname(__FILE__) + '/**/*rb'].
   reject{|f| f.end_with? 'browse.rb'}.
-  each{|f| require_relative f}
+  each{|f| f[0] == '/' ? require(f) : require_relative(f) }

--- a/lib/read-ruby/chapter.rb
+++ b/lib/read-ruby/chapter.rb
@@ -90,7 +90,7 @@ class Chapter < Mustache
     footnotes
     nok.css('figure').map do |fig|
       if fig['id'] and fig['id'].end_with?('.rb')
-          fig.at("figcaption").before(Example.target(fig['id']).read)
+        fig.at("figcaption").before(Example.target(fig['id']).sub('.html','.rb').read)
       elsif fig['class'] == 'railroad' 
         fig.css('img').each do |img|
           railroad = Railroad.target(img['id'])


### PR DESCRIPTION
The current not-working thing is:
    bundle exec rake --trace
    (in /apps/read-ruby)
    *\* Invoke default (first_time)
    *\* Invoke html (first_time)
    *\* Execute html
    cp -r www out
    rake aborted!
    No such file or directory - out/chapter.mustache
    /home/micha/.rvm/rubies/ruby-1.9.2-preview1/lib/ruby/1.9.1/pathname.rb:831:in `read'
    /home/micha/.rvm/rubies/ruby-1.9.2-preview1/lib/ruby/1.9.1/pathname.rb:831:in`read'
    /apps/read-ruby/Rakefile:22:in `rescue in block (2 levels) in <top (required)>'
    /apps/read-ruby/Rakefile:17:in`block (2 levels) in <top (required)>'
    /apps/read-ruby/Rakefile:13:in `each'
    /apps/read-ruby/Rakefile:13:in`block in <top (required)>'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:636:in `call'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:636:in`block in execute'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:631:in `each'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:631:in`execute'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:597:in `block in invoke_with_call_chain'
    /home/micha/.rvm/rubies/ruby-1.9.2-preview1/lib/ruby/1.9.1/monitor.rb:190:in`mon_synchronize'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:590:in `invoke_with_call_chain'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:607:in`block in invoke_prerequisites'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:604:in `each'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:604:in`invoke_prerequisites'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:596:in `block in invoke_with_call_chain'
    /home/micha/.rvm/rubies/ruby-1.9.2-preview1/lib/ruby/1.9.1/monitor.rb:190:in`mon_synchronize'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:590:in `invoke_with_call_chain'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:583:in`invoke'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:2051:in `invoke_task'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:2029:in`block (2 levels) in top_level'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:2029:in `each'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:2029:in`block in top_level'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:2068:in `standard_exception_handling'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:2023:in`top_level'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:2001:in `block in run'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:2068:in`standard_exception_handling'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/lib/rake.rb:1998:in `run'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/gems/rake-0.8.7/bin/rake:31:in`<top (required)>'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/bin/rake:19:in `load'
    /home/micha/.rvm/gems/ruby-1.9.2-preview1/bin/rake:19:in`<main>'

Maybe its a 1.9 issue, maybe it helps if you document the exact version of 1.9 you are using.

cheers mg
