### PR TITLE
Description of nanosecond attribute of Time is incorrect

### DIFF
--- a/src/times.xml
+++ b/src/times.xml
@@ -97,7 +97,7 @@
 	</tr>
 	<tr>
 	  <td>Nanoseconds</td>
-	  <td>Nanosecond<footnote><para>1 nanosecond is 10<superscript>−9</superscript> seconds</para></footnote> of microsoecond</td>
+	  <td>Nanosecond<footnote><para>1 nanosecond is 10<superscript>−9</superscript> seconds</para></footnote> of second</td>
 	  <td><literal>Integer</literal></td>
 	  <td>0</td>
 	  <td><function>Time#nsec</function>, <function>Time#tv_nsec</function></td>


### PR DESCRIPTION
On http://ruby.runpaint.org/times#attributes, `nanosecond` is described as "Nanosecond of microsoecond". `nanosecond` is of a second, so this tiny patch just corrects the description accordingly.
